### PR TITLE
Fix typings-clean path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm_debug
 coverage/
 npm-debug.log
 debug.json
+.idea/*

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-full": "npm run clean && npm run typings && tsc",
     "build": "tsc",
     "typings": "npm run typings-clean && typings install",
-    "typings-clean": "rm -rf src/typings",
+    "typings-clean": "rm -rf typings",
     "prepublish": "npm run build-full",
     "coverage": "npm run build && istanbul cover _mocha --  build/test/*Test.js build/test/**/*Test.js"
   },


### PR DESCRIPTION
Fix typings-clean path - the typings folder is in same dir as typings.json, which is the project root.  I ran into this while upgrading ftl-engine to TS 2.0 so it would match simple-swf.  Until I fixed this problem, I got a whole lot of weird errors (mostly 'duplicate declaration of xxxxx').

I also added my IDE settings folder to .gitignore to make contributing easier, I hope you won't mind!

Thanks for the great project :)
